### PR TITLE
Add optional chat timestamp display

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,6 @@ python list_titles.py <export.json> [more.json ...]
 ```
 
 The script supports Grok, Claude, and ChatGPT exports and will report
-the detected format for each file before listing its titles.
+the detected format for each file before listing its titles. After
+listing the titles, the script can optionally print the timestamp of
+each chat when you answer `y` to the prompt.

--- a/list_titles.py
+++ b/list_titles.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from datetime import datetime
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Optional
 
 
 def ordinal(n: int) -> str:
@@ -77,27 +77,86 @@ def load_titles(path: str) -> Tuple[str, List[str]]:
     return fmt, titles
 
 
+def load_titles_and_times(path: str) -> Tuple[str, List[Tuple[str, Optional[datetime]]]]:
+    """Return (format, [(title, datetime|None)]) for the given JSON file."""
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    fmt = detect_format(data)
+
+    results: List[Tuple[str, Optional[datetime]]] = []
+
+    def add(title: Optional[str], ts: Optional[Any]) -> None:
+        if not title:
+            return
+        dt: Optional[datetime] = None
+        if ts is not None:
+            try:
+                if isinstance(ts, (int, float)):
+                    dt = datetime.fromtimestamp(ts)
+                elif isinstance(ts, str):
+                    dt = datetime.fromisoformat(ts)
+            except Exception:
+                dt = None
+        results.append((title, dt))
+
+    if fmt == 'ChatGPT':
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                add(item.get('title') or item.get('name'), item.get('create_time') or item.get('update_time'))
+        elif isinstance(data, dict):
+            add(data.get('title') or data.get('name'), data.get('create_time') or data.get('update_time'))
+    elif fmt == 'Claude':
+        meta = data.get('meta', {}) if isinstance(data, dict) else {}
+        add(meta.get('title'), meta.get('exported_at'))
+    elif fmt == 'Grok':
+        if 'conversations' in data and isinstance(data['conversations'], list):
+            for conv in data['conversations']:
+                if not isinstance(conv, dict):
+                    continue
+                if 'conversation' in conv and isinstance(conv['conversation'], dict):
+                    obj = conv['conversation']
+                    title = obj.get('title')
+                    ts = obj.get('create_time') or obj.get('modify_time')
+                else:
+                    title = conv.get('title')
+                    ts = conv.get('create_time') or conv.get('modify_time')
+                add(title, ts)
+        else:
+            add(data.get('title'), data.get('create_time') or data.get('modify_time'))
+
+    return fmt, results
+
+
 def main():
     if len(sys.argv) < 2:
         print('Usage: python list_titles.py <export.json> [more.json ...]')
         sys.exit(1)
 
+    files: List[Tuple[str, str, List[Tuple[str, Optional[datetime]]]]] = []
+
     for path in sys.argv[1:]:
         try:
-            source, titles = load_titles(path)
+            source, info = load_titles_and_times(path)
         except Exception as e:
             print(f"{path}: failed to parse - {e}")
             continue
+        files.append((path, source, info))
         print(f"{path} ({source}):")
-        for title in sorted(titles):
+        for title, _ in sorted(info, key=lambda x: x[0]):
             print(f"  - {title}")
 
-    answer = input("Show current date and time? [y/N]: ").strip().lower()
+    answer = input("Show chat timestamps? [y/N]: ").strip().lower()
     if answer.startswith('y'):
-        now = datetime.now()
-        day = ordinal(now.day)
-        formatted = now.strftime(f"%a {day} %B %Y")
-        print(formatted)
+        for path, source, info in files:
+            print(f"{path} ({source}) timestamps:")
+            for title, ts in sorted(info, key=lambda x: x[0]):
+                if ts is None:
+                    print(f"  - {title}: n/a")
+                else:
+                    print(f"  - {title}: {ts.isoformat(sep=' ', timespec='seconds')}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add optional timestamp support to list_titles
- document new behaviour in README

## Testing
- `python3 list_titles.py examples/claude_example.json <<'EOF'
N
EOF`
- `python3 list_titles.py examples/claude_example.json examples/gpt_example.json examples/grok_example.json <<'EOF'
y
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6855d36180d8832fa737b43f705b4390