### PR TITLE
Add optional date prefix to chat titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Import Grok, Claude, ChatGPT chats into open-webui.
 ## Listing Chat Titles
 
 Use `list_titles.py` to detect the format of a chat export and print
-all conversation titles:
+all conversation titles. By default each title is prefixed with its
+timestamp in a human readable form:
 
 ```bash
 python list_titles.py <export.json> [more.json ...]
 ```
 
 The script supports Grok, Claude, and ChatGPT exports and will report
-the detected format for each file before listing its titles. After
-listing the titles, the script can optionally print the timestamp of
-each chat when you answer `y` to the prompt.
+the detected format for each file before listing its titles. Titles are
+shown with their timestamps unless you pass `--no-dates`.


### PR DESCRIPTION
## Summary
- add argparse CLI with `--no-dates`
- show chat titles prefixed with human-readable timestamps unless `--no-dates` is given
- update README to document new behaviour

## Testing
- `python list_titles.py examples/gpt_example.json --no-dates | head`
- `python list_titles.py examples/gpt_example.json | head`
- `python list_titles.py examples/test.json | head`
- `python list_titles.py examples/test.json --no-dates | head`


------
https://chatgpt.com/codex/tasks/task_e_6855d61fd5a8832fb29e73b82f2a65c7