### PR TITLE
Improve schema detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ python list_titles.py <export.json> [more.json ...]
 The script supports Grok, Claude, and ChatGPT exports and will report
 the detected format for each file before listing its titles. Titles are
 shown with their timestamps unless you pass `--no-dates`.
+
+`list_titles.py` relies on the `jsonschema` package which can be installed
+with `pip install jsonschema`.


### PR DESCRIPTION
## Summary
- validate chat export formats with bundled JSON schemas
- document jsonschema dependency

## Testing
- `python list_titles.py examples/gpt_example.json examples/claude_example.json examples/grok_example.json | head -n 20`
- `python -m py_compile list_titles.py`

------
https://chatgpt.com/codex/tasks/task_e_6855d9ad0914832fa7e27f617b8b6705