### PR TITLE
Add requirements and sort titles by date

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,9 @@ The script supports Grok, Claude, and ChatGPT exports and will report
 the detected format for each file before listing its titles. Titles are
 shown with their timestamps unless you pass `--no-dates`.
 
-`list_titles.py` relies on the `jsonschema` package which can be installed
-with `pip install jsonschema`.
+The script depends on the `jsonschema` package. Install the required
+dependencies with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/list_titles.py
+++ b/list_titles.py
@@ -191,7 +191,13 @@ def main() -> None:
 
         print(f"{path} ({source}):")
 
-        for title, ts in sorted(info, key=lambda x: x[0]):
+        def sort_key(item: Tuple[str, Optional[datetime]]) -> Tuple[float, str]:
+            title, ts = item
+            ts_value = ts.timestamp() if ts is not None else float('-inf')
+            # negative ts_value gives descending order when using ascending sort
+            return (-ts_value, title)
+
+        for title, ts in sorted(info, key=sort_key):
             if args.no_dates or ts is None:
                 print(f'  - "{title}"')
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema


### PR DESCRIPTION
## Summary
- add a `requirements.txt` with `jsonschema`
- document installing requirements in the README
- sort titles by timestamp (descending) then alphabetically

## Testing
- `python -m py_compile list_titles.py create-schema.py`
- `python list_titles.py examples/claude_example.json | head`
- `python list_titles.py examples/*.json | head`

------
https://chatgpt.com/codex/tasks/task_e_6855dcd0a120832f83de3549e4acdf28