### PR TITLE
Add optional schema validation switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ python list_titles.py <export.json> [more.json ...]
 ```
 
 The script supports Grok, Claude, and ChatGPT exports and will report
-the detected format for each file before listing its titles. Titles are
-shown with their timestamps unless you pass `--no-dates`.
+the detected format for each file before listing its titles. Detection
+normally relies on quick heuristics. Pass `--validate` to enforce JSON
+schema validation which is slower. Titles are shown with their
+timestamps unless you pass `--no-dates`.
 
 The script depends on the `jsonschema` package. Install the required
 dependencies with:


### PR DESCRIPTION
## Summary
- add a `--validate` flag for optional JSON-schema validation when detecting export format
- update detection functions to skip validation by default and use heuristics
- document new argument in README

## Testing
- `python -m py_compile list_titles.py`
- `python list_titles.py examples/claude_example.json examples/gpt_example.json examples/grok_example.json | head -n 20`
- `python list_titles.py --validate examples/claude_example.json examples/gpt_example.json examples/grok_example.json`

------
https://chatgpt.com/codex/tasks/task_e_6855df273a1c832fb3f14fc7fd0e9f6d