### PR TITLE
Add --format option to list_titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ python list_titles.py <export.json> [more.json ...]
 The script supports Grok, Claude, and ChatGPT exports and will report
 the detected format for each file before listing its titles. Detection
 normally relies on quick heuristics. Pass `--validate` to enforce JSON
-schema validation which is slower. Titles are shown with their
+schema validation which is slower. If you already know the export
+format you can pass `--format Grok`, `--format ChatGPT`, or
+`--format Claude` to skip detection. Titles are shown with their
 timestamps unless you pass `--no-dates`.
 
 The script depends on the `jsonschema` package. Install the required


### PR DESCRIPTION
## Summary
- allow specifying chat export format with `--format`
- update README with new instructions

## Testing
- `python -m py_compile list_titles.py`
- `python list_titles.py --format ChatGPT examples/gpt_example.json | head -n 4`

------
https://chatgpt.com/codex/tasks/task_e_6855e159e928832faa63350b244c7250