### PR TITLE
Update validate argument to only check schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ python list_titles.py <export.json> [more.json ...]
 
 The script supports Grok, Claude, and ChatGPT exports and will report
 the detected format for each file before listing its titles. Detection
-normally relies on quick heuristics. Pass `--validate` to enforce JSON
-schema validation which is slower. If you already know the export
-format you can pass `--format Grok`, `--format ChatGPT`, or
+normally relies on quick heuristics. Use `--validate` to only check the
+file against the appropriate JSON schema; the script will output
+"Validation successful" or "Validation failed". If you already know the
+export format you can pass `--format Grok`, `--format ChatGPT`, or
 `--format Claude` to skip detection. Claude exports can be either a
 list of conversations or an object containing `meta` and `conversations`
 data. Titles are shown with their timestamps unless you pass

--- a/list_titles.py
+++ b/list_titles.py
@@ -291,7 +291,7 @@ def main() -> None:
     parser.add_argument(
         "--validate",
         action="store_true",
-        help="Validate input using JSON schemas (slower)",
+        help="Validate input using JSON schemas and exit",
     )
     parser.add_argument(
         "--format",
@@ -299,6 +299,29 @@ def main() -> None:
         help="Specify the chat export format to skip auto-detection",
     )
     args = parser.parse_args()
+
+    if args.validate:
+        for path in args.files:
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+
+                fmt = args.format or detect_format(data)
+                if fmt == "ChatGPT":
+                    schema = CHATGPT_SCHEMA
+                elif fmt == "Grok":
+                    schema = GROK_SCHEMA
+                elif fmt == "Claude":
+                    schema = CLAUDE_SCHEMA_EXAMPLE
+                else:
+                    raise ValueError("Unknown format")
+
+                validate(instance=data, schema=schema)
+            except Exception:
+                print("Validation failed")
+            else:
+                print("Validation successful")
+        return
 
     for path in args.files:
         try:


### PR DESCRIPTION
## Summary
- change `--validate` option in `list_titles.py` to only validate chat export files
- update README to reflect new validation behavior

## Testing
- `python -m py_compile list_titles.py create-schema.py`
- `python list_titles.py --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6855e6b9d9b0832f8ecdd812e58afb1c