### PR TITLE
Fix multi-turn conversation parsing and update examples

### DIFF
--- a/examples/claude_example.json
+++ b/examples/claude_example.json
@@ -2,66 +2,24 @@
   "conversations": [
     {
       "conversation": {
-        "title": "Why do leaves change color in autumn?",
-        "summary": "A discussion about the science behind autumn leaf colors, including the role of chlorophyll, carotenoids, and anthocyanins, and how environmental factors influence the process."
+        "title": "Why do leaves change color in autumn?"
       },
-      "responses": [
+      "chat_messages": [
         {
-          "response": {
-            "text": "Leaves change color in autumn primarily due to the breakdown of chlorophyll, the pigment responsible for the green color in leaves. As daylight hours shorten and temperatures drop, trees begin to prepare for winter by slowing down their food production. Chlorophyll degrades, revealing other pigments such as carotenoids, which produce yellow and orange hues, and anthocyanins, which create reds and purples. The intensity and variety of colors can be influenced by weather conditions, such as temperature, light, and water supply. For example, a series of warm, sunny days and cool, crisp nights tends to produce the most vibrant red colors. This process is an adaptation that helps trees conserve energy and resources during the colder months when water is less available and photosynthesis is less efficient."
-          }
-        }
-      ]
-    },
-    {
-      "conversation": {
-        "title": "How does photosynthesis work?",
-        "summary": "An explanation of the process of photosynthesis, detailing how plants convert sunlight into energy, the role of chlorophyll, and the importance of this process for life on Earth."
-      },
-      "responses": [
+          "role": "user",
+          "text": "Why do leaves change color in autumn?"
+        },
         {
-          "response": {
-            "text": "Photosynthesis is the process by which green plants, algae, and some bacteria convert light energy, usually from the sun, into chemical energy stored in glucose. This process takes place mainly in the chloroplasts of plant cells, where the pigment chlorophyll absorbs sunlight. During photosynthesis, plants take in carbon dioxide from the air and water from the soil. Using the energy from sunlight, these raw materials are transformed into glucose and oxygen. The overall chemical equation for photosynthesis is: 6CO2 + 6H2O + light energy → C6H12O6 + 6O2. The glucose produced provides energy for the plant's growth and development, while the oxygen is released into the atmosphere as a byproduct. Photosynthesis is essential for life on Earth because it forms the base of the food chain and supplies the oxygen that most organisms need to breathe."
-          }
-        }
-      ]
-    },
-    {
-      "conversation": {
-        "title": "What causes rainbows?",
-        "summary": "A detailed look at the science behind rainbows, including the refraction, dispersion, and reflection of light in water droplets, and why we see different colors."
-      },
-      "responses": [
+          "role": "assistant",
+          "text": "Leaves change color as chlorophyll breaks down, revealing other pigments like carotenoids and anthocyanins."
+        },
         {
-          "response": {
-            "text": "Rainbows are optical phenomena that occur when sunlight passes through raindrops in the atmosphere. The process involves three main steps: refraction, dispersion, and reflection. First, as sunlight enters a raindrop, it slows down and bends, a process known as refraction. Next, the light is dispersed, or spread out, into its component colors because different wavelengths of light bend by different amounts. This separation of colors creates the spectrum we see in a rainbow. Finally, the light is reflected off the inside surface of the raindrop and refracted again as it exits the drop, further spreading the colors. The result is a circular arc of colors, with red on the outside and violet on the inside. The specific angle at which the light is refracted and reflected determines the position and appearance of the rainbow."
-          }
-        }
-      ]
-    },
-    {
-      "conversation": {
-        "title": "How do airplanes fly?",
-        "summary": "An overview of the principles of flight, including lift, thrust, drag, and weight, and how airplane wings generate lift to keep the aircraft in the air."
-      },
-      "responses": [
+          "role": "user",
+          "text": "Does temperature affect the colors?"
+        },
         {
-          "response": {
-            "text": "Airplanes fly by generating lift, a force that opposes gravity and allows the aircraft to rise into the air. The wings of an airplane are specially shaped to create a difference in air pressure above and below the wing as the plane moves forward. This shape, called an airfoil, causes air to move faster over the top of the wing and slower underneath, resulting in lower pressure above and higher pressure below. This pressure difference produces lift. In addition to lift, airplanes require thrust to move forward, which is provided by engines or propellers. Thrust must overcome drag, the resistance caused by air friction. The four main forces acting on an airplane are lift, weight (gravity), thrust, and drag. By carefully balancing these forces, pilots can control the altitude, speed, and direction of the aircraft."
-          }
-        }
-      ]
-    },
-    {
-      "conversation": {
-        "title": "What is the water cycle?",
-        "summary": "A comprehensive explanation of the water cycle, describing the processes of evaporation, condensation, precipitation, and collection, and their importance to Earth's ecosystems."
-      },
-      "responses": [
-        {
-          "response": {
-            "text": "The water cycle, also known as the hydrological cycle, is the continuous movement of water on, above, and below the surface of the Earth. It begins with evaporation, where heat from the sun causes water from oceans, lakes, and rivers to turn into water vapor and rise into the atmosphere. Plants also contribute through transpiration, releasing water vapor from their leaves. As the water vapor rises, it cools and condenses to form clouds in a process called condensation. When the clouds become heavy enough, the water falls back to the Earth's surface as precipitation, such as rain, snow, sleet, or hail. Some of this water runs off into rivers and streams, eventually returning to the oceans, while some infiltrates the ground and replenishes groundwater supplies. The water cycle is essential for distributing fresh water across the planet and supporting all forms of life."
-          }
+          "role": "assistant",
+          "text": "Yes, temperature and sunlight influence the intensity of autumn leaf colors."
         }
       ]
     }

--- a/examples/gpt_example.json
+++ b/examples/gpt_example.json
@@ -16,6 +16,20 @@
           "text": "Rainbows are formed when sunlight passes through raindrops, which act as prisms and split the light into its different colors."
         }
       ]
+    },
+    {
+      "text": "Can animals see rainbows?",
+      "content": [
+        {"text": "Can animals see rainbows?"}
+      ]
+    },
+    {
+      "text": "Many animals can perceive some colors but not all; they may not see rainbows in the same way humans do.",
+      "content": [
+        {
+          "text": "Many animals can perceive some colors but not all; they may not see rainbows in the same way humans do."
+        }
+      ]
     }
   ]
 }

--- a/examples/grok_example.json
+++ b/examples/grok_example.json
@@ -3,20 +3,30 @@
   "mapping": {
     "client-created-root": {
       "message": {
-        "content": {
-          "content_type": "text",
-          "parts": ["Can you explain how photosynthesis works in simple terms?"]
-        }
+        "author": {"role": "user"},
+        "content": {"content_type": "text", "parts": ["Can you explain how photosynthesis works in simple terms?"]},
+        "create_time": "2024-01-01T00:00:00Z"
       }
     },
-    "41512317-7d30-4caa-84e1-4f12db70ef42": {
+    "a1": {
       "message": {
-        "content": {
-          "content_type": "text",
-          "parts": [
-            "Photosynthesis is the process by which plants use sunlight to convert water and carbon dioxide into oxygen and glucose. It helps plants make their own food."
-          ]
-        }
+        "author": {"role": "assistant"},
+        "content": {"content_type": "text", "parts": ["Photosynthesis is the process by which plants convert water and carbon dioxide into oxygen and glucose using sunlight."]},
+        "create_time": "2024-01-01T00:00:10Z"
+      }
+    },
+    "a2": {
+      "message": {
+        "author": {"role": "user"},
+        "content": {"content_type": "text", "parts": ["Why is sunlight important?"]},
+        "create_time": "2024-01-01T00:00:20Z"
+      }
+    },
+    "a3": {
+      "message": {
+        "author": {"role": "assistant"},
+        "content": {"content_type": "text", "parts": ["Sunlight provides the energy needed to drive the chemical reactions in photosynthesis."]},
+        "create_time": "2024-01-01T00:00:30Z"
       }
     }
   }


### PR DESCRIPTION
## Summary
- support Claude chat exports that use `chat_messages`
- parse all messages for ChatGPT and Grok exports
- add multi-turn conversation data to the example JSON files

## Testing
- `python convert.py --userid user1 examples/gpt_example.json examples/claude_example.json examples/grok_example.json`
- `python -m py_compile convert.py create_sql.py create-schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6856990c7938832fa55bbcc6e50a960f