### PR TITLE
Enable id-based filenames and SQL upsert

### DIFF
--- a/convert_chatgpt.py
+++ b/convert_chatgpt.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Tuple
 
 MODEL = "openai/chatgpt-4o-latest"
 MODEL_NAME = "ChatGPT 4o (latest)"
+SUBDIR = "chatgpt"
 
 
 def extract_last_sentence(text: str) -> str:
@@ -47,6 +48,7 @@ def parse_chatgpt(data: Any) -> List[dict]:
         title = item.get("title") or item.get("name") or "Untitled"
         ts_raw = item.get("create_time") or item.get("update_time") or time.time()
         ts = parse_timestamp(ts_raw, time.time())
+        conv_id = item.get("conversation_id") or item.get("id")
         messages: List[Tuple[str, str, float]] = []
         if isinstance(item.get("chat_messages"), list):
             for idx, msg in enumerate(item["chat_messages"]):
@@ -76,7 +78,12 @@ def parse_chatgpt(data: Any) -> List[dict]:
                     next_ids = node.get("children") or []
         else:
             messages.append(("user", title, ts))
-        result.append({"title": title, "timestamp": ts, "messages": messages})
+        result.append({
+            "title": title,
+            "timestamp": ts,
+            "messages": messages,
+            "conversation_id": conv_id,
+        })
     return result
 
 
@@ -143,7 +150,9 @@ def convert_file(path: str, user_id: str, outdir: str) -> None:
     os.makedirs(outdir, exist_ok=True)
     for conv in conversations:
         out, conv_uuid = build_webui(conv, user_id)
-        fname = f"{slugify(conv['title'])}_{conv_uuid}.json"
+        conv_id = conv.get("conversation_id")
+        unique = conv_id if conv_id else conv_uuid
+        fname = f"{slugify(conv['title'])}_{unique}.json"
         with open(os.path.join(outdir, fname), "w", encoding="utf-8") as fh:
             json.dump(out, fh, ensure_ascii=False, indent=2)
 
@@ -154,9 +163,10 @@ def run_cli() -> None:
     parser.add_argument("--userid", required=True, help="User ID for output files")
     parser.add_argument("--output-dir", default="output", help="Directory for output JSON files")
     args = parser.parse_args()
+    outdir = os.path.join(args.output_dir, SUBDIR)
     for path in args.files:
         try:
-            convert_file(path, args.userid, args.output_dir)
+            convert_file(path, args.userid, outdir)
         except Exception as exc:
             print(f"Failed to convert {path}: {exc}")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,14 +35,19 @@ usage: convert_claude.py [-h] --userid USERID [--output-dir OUTPUT_DIR] files [f
 Convert Claude exports to open-webui JSON
 ```
 
+All converter scripts name the output files using the original conversation ID
+so running them again will produce the same filename for the same conversation.
+Converted files are saved in a subdirectory named after the model (for example
+`output/grok` or `output/claude`).
+
 ### create_sql.py
 
 ```
 usage: create_sql.py [-h] [--tags TAGS] [--output OUTPUT] files [files ...]
 
-Create SQL inserts for open-webui chats. The output also contains UPSERT
-statements that ensure the default import tags, as well as any tags passed via
-`--tags`, exist for each user.
+Create SQL inserts for open-webui chats. The output contains UPSERT
+statements that ensure chat records and the default import tags (as well as any
+tags passed via `--tags`) exist for each user.
 
 positional arguments:
   files            Chat JSON files or directories
@@ -68,11 +73,13 @@ Output will be saved as <input_file>_schema.json
    ```bash
    python ./convert_grok.py --userid="d95194d2-9cef-4387-8ee4-b82eb2e1c637" ./grok.json
    ```
+   The converter writes JSON files to a subdirectory such as `output/grok`.
 4. Generate SQL statements from the converted JSON files:
    ```bash
    python ./create_sql.py ./output --tags="imported, grok" --output=grok.sql
    ```
-   The resulting SQL includes tag UPSERTs so the imported records can be tagged
-   appropriately. Any tags passed with `--tags` are also created for each user.
+   The resulting SQL includes UPSERTs so existing chats and tags are updated if
+   they already exist. Any tags passed with `--tags` are also created for each
+   user.
 5. Make a copy of your `webui.db` database.
 6. Execute the generated SQL using a tool such as [DB Browser for SQLite](https://sqlitebrowser.org/dl/).


### PR DESCRIPTION
## Summary
- persist conversation identifiers in converters
- use conversation ID in output filenames for deterministic names
- upsert chat data in `create_sql.py`
- update README for UPSERT behaviour and deterministic filenames
- store converter output files in subdirectories by model

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685731a2ac28832f93abdad5fe844067