### PR TITLE
Fix chat insert without ON CONFLICT

### DIFF
--- a/create_sql.py
+++ b/create_sql.py
@@ -77,11 +77,9 @@ def json_to_sql(path: str, tags: list[str]) -> tuple[str, str]:
     meta = build_meta(tags)
 
     sql = (
+        f'DELETE FROM "main"."chat" WHERE "id" = "{record_id}";\n'
         'INSERT INTO "main"."chat" ("id","user_id","title","share_id","archived","created_at","updated_at","chat","pinned","meta","folder_id")\n'
-        f"VALUES ('{record_id}','{user_id}','{title}',NULL,0,{created_at},{created_at},'{chat_json}',0,'{meta}',NULL)\n"
-        'ON CONFLICT("id","user_id") DO UPDATE SET '
-        '"title"=excluded."title", "chat"=excluded."chat", "meta"=excluded."meta", '
-        '"updated_at"=excluded."updated_at";'
+        f"VALUES ('{record_id}','{user_id}','{title}',NULL,0,{created_at},{created_at},'{chat_json}',0,'{meta}',NULL);"
     )
     return sql, user_id
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,9 +45,10 @@ Converted files are saved in a subdirectory named after the model (for example
 ```
 usage: create_sql.py [-h] [--tags TAGS] [--output OUTPUT] files [files ...]
 
-Create SQL inserts for open-webui chats. The output contains UPSERT
-statements that ensure chat records and the default import tags (as well as any
-tags passed via `--tags`) exist for each user.
+Create SQL inserts for open-webui chats. Existing chat records are deleted
+before inserting so they are replaced if already present. Tags are inserted
+with UPSERT statements, ensuring the default import tags (and any tags passed
+via `--tags`) exist for each user.
 
 positional arguments:
   files            Chat JSON files or directories
@@ -78,8 +79,9 @@ Output will be saved as <input_file>_schema.json
    ```bash
    python ./create_sql.py ./output --tags="imported, grok" --output=grok.sql
    ```
-   The resulting SQL includes UPSERTs so existing chats and tags are updated if
-   they already exist. Any tags passed with `--tags` are also created for each
-   user.
+   The resulting SQL removes any existing chats with the same IDs before
+   inserting new ones, while tags are inserted using UPSERTs so they are
+   updated if they already exist. Any tags passed with `--tags` are also created
+   for each user.
 5. Make a copy of your `webui.db` database.
 6. Execute the generated SQL using a tool such as [DB Browser for SQLite](https://sqlitebrowser.org/dl/).


### PR DESCRIPTION
## Summary
- generate SQL for chats by deleting any existing row before inserting
- document new delete/insert approach in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573c567510832f83d8a2c16a9536ca