### PR TITLE
Fix ChatGPT import root handling

### DIFF
--- a/convert_chatgpt.py
+++ b/convert_chatgpt.py
@@ -76,6 +76,14 @@ def parse_chatgpt(data: Any) -> List[dict]:
         elif isinstance(item.get("mapping"), dict):
             mapping = item["mapping"]
             node = mapping.get("client-created-root")
+            if not isinstance(node, dict):
+                # Some exports don't use the "client-created-root" key. In
+                # those cases, attempt to locate the root node by finding the
+                # entry with no parent value.
+                for val in mapping.values():
+                    if isinstance(val, dict) and not val.get("parent"):
+                        node = val
+                        break
             if isinstance(node, dict):
                 next_ids = node.get("children") or []
                 while next_ids:

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,6 +1,12 @@
 import json
 import uuid
 import types
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 import convert_chatgpt
 import convert_claude
@@ -54,3 +60,5 @@ def test_grok_conversion(monkeypatch):
     result = _run_conversion(convert_grok, "examples/grok_example.json", monkeypatch)
     expected = _load_expected("grok")
     assert result == expected
+
+


### PR DESCRIPTION
## Summary
- support ChatGPT exports that omit `client-created-root`
- ensure tests can import modules directly
- remove temporary regression test and sample files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f3503ee4832f8ba56120f871f3b3