### PR TITLE
Fix: Adding some extra headers to the output json to make it compatible with Open-WebUI 0.6.20

### DIFF
--- a/convert_chatgpt.py
+++ b/convert_chatgpt.py
@@ -211,8 +211,14 @@ def convert_file(path: str, user_id: str, outdir: str) -> None:
         conv_id = conv.get("conversation_id")
         unique = conv_id if conv_id else conv_uuid
         fname = f"{slugify(conv['title'])}_{unique}.json"
+        outer = {
+            "id": "",
+            "user_id": user_id,
+            "title": conv.get("title", ""),
+            "chat": out
+        }
         with open(os.path.join(outdir, fname), "w", encoding="utf-8") as fh:
-            json.dump(out, fh, ensure_ascii=False, indent=2)
+            json.dump([outer], fh, ensure_ascii=False, indent=2)
 
 
 def run_cli() -> None:


### PR DESCRIPTION
The conversion was not working with Open-WebUI version 0.6.20. Looking at an export from that version, seems that some extra objects are now mandatory before starting to dump the chat structure:

```
outer = {
    "id": "",
    "user_id": user_id,
    "title": conv.get("title", ""),
    "chat": out
}
```

Adding that fixed the import for me.

Edit: new PR, I messed up the other by PR the main, sorry about that!