### PR TITLE
fix: stop dropping tool_use/tool_result content on Claude import

### DIFF
--- a/convert_claude.py
+++ b/convert_claude.py
@@ -7,7 +7,7 @@ import os
 import re
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
 
 INVALID_RE = re.compile(r"[\ue000-\uf8ff]")
@@ -53,7 +53,16 @@ def _parse_iso_datetime(value: Any) -> datetime | None:
         except ValueError:
             return None
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value))
+        # Claude's own start_timestamp/stop_timestamp are always ISO strings
+        # with a Z, i.e. UTC. This branch exists for other callers of the
+        # same helper, but datetime.fromtimestamp() without a tz interprets
+        # the value in the *local* system timezone, not UTC. Mixed with the
+        # string branch above (always UTC), that produced two bugs at once:
+        # a wrong duration on any machine not set to UTC, and a hard crash
+        # when the two were compared, since Python refuses to compare an
+        # aware datetime against a naive one. Pinning this to UTC matches the
+        # string branch and makes the two comparable.
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
     return None
 
 
@@ -98,9 +107,52 @@ def _format_reasoning_block(part: dict) -> str:
     )
 
 
+def _format_tool_use(part: dict) -> str:
+    name = part.get("name") or "tool"
+    tool_input = part.get("input")
+    try:
+        input_str = json.dumps(tool_input, ensure_ascii=False) if tool_input else ""
+    except TypeError:
+        input_str = str(tool_input)
+    header = f"🔧 used **{name}**"
+    return f"{header}\n```json\n{input_str}\n```" if input_str else header
+
+
+def _format_tool_result(part: dict) -> str:
+    content = part.get("content")
+    text = ""
+    if isinstance(content, list):
+        pieces = []
+        for entry in content:
+            if isinstance(entry, dict) and entry.get("type") == "text":
+                piece = sanitize_text(entry.get("text"))
+                if piece:
+                    pieces.append(piece)
+            elif isinstance(entry, str):
+                piece = sanitize_text(entry)
+                if piece:
+                    pieces.append(piece)
+        text = "\n".join(pieces)
+    elif isinstance(content, str):
+        text = sanitize_text(content)
+    if not text:
+        return ""
+    return f"↳ tool result:\n{text}"
+
+
 def _content_to_text(parts: list[Any]) -> str:
     reasoning_segments: List[str] = []
-    text_segments: List[str] = []
+    # Everything that isn't a "thinking" block, in the order Claude produced
+    # it. tool_use and tool_result used to have no handler at all: a real
+    # export where the assistant called a tool (web search, code execution,
+    # the analysis tool — any of these produce this same content shape) had
+    # that content silently discarded. When a turn's ONLY content was a tool
+    # call and its result, with the answer arriving in a later turn, the
+    # whole message vanished from the import: _parse_message_list drops any
+    # message whose extracted text comes back empty. That is not a rendering
+    # nuance, it is conversation history disappearing with no error and
+    # nothing in the output hinting that anything is missing.
+    other_segments: List[str] = []
     for part in parts:
         if not isinstance(part, dict):
             continue
@@ -112,12 +164,27 @@ def _content_to_text(parts: list[Any]) -> str:
         elif p_type == "text":
             text = sanitize_text(part.get("text"))
             if text:
-                text_segments.append(text)
+                other_segments.append(text)
+        elif p_type == "tool_use":
+            block = _format_tool_use(part)
+            if block:
+                other_segments.append(block)
+        elif p_type == "tool_result":
+            block = _format_tool_result(part)
+            if block:
+                other_segments.append(block)
+        elif p_type:
+            # Anything else (image, document, and whatever Anthropic adds
+            # next) is content we don't know how to render, but dropping it
+            # with no trace is worse than an honest placeholder: a reader
+            # comparing the import against the original at least knows to
+            # look, instead of assuming the conversation was this short.
+            other_segments.append(f"[unsupported content: type={p_type}]")
     segments: List[str] = []
     if reasoning_segments:
         segments.append("\n".join(reasoning_segments))
-    if text_segments:
-        segments.append("\n\n".join(text_segments))
+    if other_segments:
+        segments.append("\n\n".join(other_segments))
     return "\n\n".join(segments) if segments else ""
 
 

--- a/examples/claude_tooluse_example.json
+++ b/examples/claude_tooluse_example.json
@@ -1,0 +1,120 @@
+[
+  {
+    "uuid": "7b1e2b3a-1111-4a1a-9c1a-000000000001",
+    "name": "Tokyo weather",
+    "created_at": "2026-01-01T00:00:00.000000Z",
+    "updated_at": "2026-01-01T00:05:00.000000Z",
+    "account": {
+      "uuid": "9f6b23a1-4e97-43b3-b2e1-dc6e3f94d9c8"
+    },
+    "chat_messages": [
+      {
+        "uuid": "m1",
+        "text": "",
+        "content": [
+          {
+            "type": "text",
+            "text": "What's the weather in Tokyo right now?"
+          }
+        ],
+        "sender": "human",
+        "created_at": "2026-01-01T00:00:01.000000Z",
+        "updated_at": "2026-01-01T00:00:01.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "m2",
+        "text": "",
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "web_search",
+            "input": {
+              "query": "Tokyo weather now"
+            }
+          },
+          {
+            "type": "tool_result",
+            "content": [
+              {
+                "type": "text",
+                "text": "68F, clear skies"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "text": "It's 68F and clear in Tokyo right now."
+          }
+        ],
+        "sender": "assistant",
+        "created_at": "2026-01-01T00:00:02.000000Z",
+        "updated_at": "2026-01-01T00:00:02.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "m3",
+        "text": "",
+        "content": [
+          {
+            "type": "text",
+            "text": "Also, is it going to rain tomorrow?"
+          }
+        ],
+        "sender": "human",
+        "created_at": "2026-01-01T00:00:03.000000Z",
+        "updated_at": "2026-01-01T00:00:03.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "m4",
+        "text": "",
+        "content": [
+          {
+            "type": "tool_use",
+            "name": "web_search",
+            "input": {
+              "query": "Tokyo forecast tomorrow"
+            }
+          },
+          {
+            "type": "tool_result",
+            "content": [
+              {
+                "type": "text",
+                "text": "60% chance of rain"
+              }
+            ]
+          }
+        ],
+        "sender": "assistant",
+        "created_at": "2026-01-01T00:00:04.000000Z",
+        "updated_at": "2026-01-01T00:00:04.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "m5",
+        "text": "",
+        "content": [
+          {
+            "type": "image",
+            "source": {
+              "type": "base64",
+              "media_type": "image/png",
+              "data": "iVBORw0KGgo="
+            }
+          }
+        ],
+        "sender": "human",
+        "created_at": "2026-01-01T00:00:05.000000Z",
+        "updated_at": "2026-01-01T00:00:05.000000Z",
+        "attachments": [],
+        "files": []
+      }
+    ]
+  }
+]

--- a/tests/expected/claude_tooluse_output.json
+++ b/tests/expected/claude_tooluse_output.json
@@ -1,0 +1,177 @@
+{
+  "id": "",
+  "title": "Tokyo weather",
+  "models": [
+    "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+  ],
+  "params": {},
+  "history": {
+    "messages": {
+      "00000000-0000-0000-0000-000000000002": {
+        "id": "00000000-0000-0000-0000-000000000002",
+        "parentId": null,
+        "childrenIds": [
+          "00000000-0000-0000-0000-000000000003"
+        ],
+        "role": "user",
+        "content": "What's the weather in Tokyo right now?",
+        "timestamp": 1767225601,
+        "models": [
+          "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+        ]
+      },
+      "00000000-0000-0000-0000-000000000003": {
+        "id": "00000000-0000-0000-0000-000000000003",
+        "parentId": "00000000-0000-0000-0000-000000000002",
+        "childrenIds": [
+          "00000000-0000-0000-0000-000000000004"
+        ],
+        "role": "assistant",
+        "content": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo weather now\"}\n```\n\n↳ tool result:\n68F, clear skies\n\nIt's 68F and clear in Tokyo right now.",
+        "timestamp": 1767225602,
+        "model": "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think",
+        "modelName": "anthropic/claude-4.5-sonnet-with-thinking",
+        "modelIdx": 0,
+        "userContext": null,
+        "lastSentence": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo weather now\"}\n```\n\n↳ tool result:\n68F, clear skies\n\nIt's 68F and clear in Tokyo right now.",
+        "usage": {
+          "prompt_tokens": 0,
+          "completion_tokens": 0,
+          "total_tokens": 0
+        },
+        "done": true
+      },
+      "00000000-0000-0000-0000-000000000004": {
+        "id": "00000000-0000-0000-0000-000000000004",
+        "parentId": "00000000-0000-0000-0000-000000000003",
+        "childrenIds": [
+          "00000000-0000-0000-0000-000000000005"
+        ],
+        "role": "user",
+        "content": "Also, is it going to rain tomorrow?",
+        "timestamp": 1767225603,
+        "models": [
+          "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+        ]
+      },
+      "00000000-0000-0000-0000-000000000005": {
+        "id": "00000000-0000-0000-0000-000000000005",
+        "parentId": "00000000-0000-0000-0000-000000000004",
+        "childrenIds": [
+          "00000000-0000-0000-0000-000000000006"
+        ],
+        "role": "assistant",
+        "content": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo forecast tomorrow\"}\n```\n\n↳ tool result:\n60% chance of rain",
+        "timestamp": 1767225604,
+        "model": "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think",
+        "modelName": "anthropic/claude-4.5-sonnet-with-thinking",
+        "modelIdx": 0,
+        "userContext": null,
+        "lastSentence": "60% chance of rain",
+        "usage": {
+          "prompt_tokens": 0,
+          "completion_tokens": 0,
+          "total_tokens": 0
+        },
+        "done": true
+      },
+      "00000000-0000-0000-0000-000000000006": {
+        "id": "00000000-0000-0000-0000-000000000006",
+        "parentId": "00000000-0000-0000-0000-000000000005",
+        "childrenIds": [],
+        "role": "user",
+        "content": "[unsupported content: type=image]",
+        "timestamp": 1767225605,
+        "models": [
+          "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+        ]
+      }
+    },
+    "currentId": "00000000-0000-0000-0000-000000000006"
+  },
+  "messages": [
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "parentId": null,
+      "childrenIds": [
+        "00000000-0000-0000-0000-000000000003"
+      ],
+      "role": "user",
+      "content": "What's the weather in Tokyo right now?",
+      "timestamp": 1767225601,
+      "models": [
+        "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "parentId": "00000000-0000-0000-0000-000000000002",
+      "childrenIds": [
+        "00000000-0000-0000-0000-000000000004"
+      ],
+      "role": "assistant",
+      "content": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo weather now\"}\n```\n\n↳ tool result:\n68F, clear skies\n\nIt's 68F and clear in Tokyo right now.",
+      "timestamp": 1767225602,
+      "model": "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think",
+      "modelName": "anthropic/claude-4.5-sonnet-with-thinking",
+      "modelIdx": 0,
+      "userContext": null,
+      "lastSentence": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo weather now\"}\n```\n\n↳ tool result:\n68F, clear skies\n\nIt's 68F and clear in Tokyo right now.",
+      "usage": {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0
+      },
+      "done": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000004",
+      "parentId": "00000000-0000-0000-0000-000000000003",
+      "childrenIds": [
+        "00000000-0000-0000-0000-000000000005"
+      ],
+      "role": "user",
+      "content": "Also, is it going to rain tomorrow?",
+      "timestamp": 1767225603,
+      "models": [
+        "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000005",
+      "parentId": "00000000-0000-0000-0000-000000000004",
+      "childrenIds": [
+        "00000000-0000-0000-0000-000000000006"
+      ],
+      "role": "assistant",
+      "content": "🔧 used **web_search**\n```json\n{\"query\": \"Tokyo forecast tomorrow\"}\n```\n\n↳ tool result:\n60% chance of rain",
+      "timestamp": 1767225604,
+      "model": "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think",
+      "modelName": "anthropic/claude-4.5-sonnet-with-thinking",
+      "modelIdx": 0,
+      "userContext": null,
+      "lastSentence": "60% chance of rain",
+      "usage": {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0
+      },
+      "done": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000006",
+      "parentId": "00000000-0000-0000-0000-000000000005",
+      "childrenIds": [],
+      "role": "user",
+      "content": "[unsupported content: type=image]",
+      "timestamp": 1767225605,
+      "models": [
+        "claude_4_5_with_thinking.claude-sonnet-4-5-20250929-think"
+      ]
+    }
+  ],
+  "tags": [],
+  "timestamp": 1767225600000,
+  "files": [],
+  "userId": "user"
+}

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -62,6 +62,18 @@ def test_claude_thinking_conversion(monkeypatch):
     assert result == expected
 
 
+def test_claude_tooluse_conversion(monkeypatch):
+    # Regression test for tool_use/tool_result content, which used to have no
+    # handler at all. A turn whose only content was a tool call and its
+    # result (no separate text block) vanished from the import entirely,
+    # since _parse_message_list drops any message whose extracted text comes
+    # back empty. See examples/claude_tooluse_example.json's fourth message.
+    result = _run_conversion(convert_claude, "examples/claude_tooluse_example.json", monkeypatch)
+    expected = _load_expected("claude_tooluse")
+    assert result == expected
+    assert len(result["messages"]) == 5, "the tool-only turn must not be dropped"
+
+
 def test_grok_conversion(monkeypatch):
     result = _run_conversion(convert_grok, "examples/grok_example.json", monkeypatch)
     expected = _load_expected("grok")
@@ -72,4 +84,21 @@ def test_invalid_unicode(monkeypatch):
     result = _run_conversion(convert_chatgpt, "examples/invalid_unicode.json", monkeypatch)
     expected = _load_expected("invalid_unicode")
     assert result == expected
+
+
+def test_reasoning_block_mixed_timestamp_types():
+    # _parse_iso_datetime had two branches: an ISO string is always UTC
+    # (Claude's exports use "Z"), but a bare number went through
+    # datetime.fromtimestamp() with no tz, which uses the *local* system
+    # timezone. Comparing one aware and one naive datetime raises TypeError
+    # regardless of what the values are, so any thinking block mixing the two
+    # timestamp shapes crashed conversion outright.
+    part = {
+        "type": "thinking",
+        "thinking": "Let me think about this.",
+        "start_timestamp": "2026-01-01T00:00:00Z",
+        "stop_timestamp": 1767225605,
+    }
+    block = convert_claude._format_reasoning_block(part)
+    assert 'duration="5"' in block
 


### PR DESCRIPTION
While migrating a real, sizeable Claude Open WebUI history using this tool, I traced `convert_claude.py` against a live Open WebUI database to verify the merge, which turned up a real fidelity bug worth fixing at the source rather than patching around.

## The bug

`_content_to_text` only handles `type == "thinking"` and `type == "text"` content blocks. A real Claude.ai export where the assistant used a tool — web search, code execution, and the analysis tool all produce this same `tool_use`/`tool_result` content shape — has that content silently discarded, with no error and nothing in the output hinting anything is missing.

The worst case isn't cosmetic. When an assistant turn's *only* content is a `tool_use`/`tool_result` pair (the final answer arrives in a separate later turn, which is common), the extracted text comes back empty, and `_parse_message_list` drops any message with empty text. **The whole turn disappears from the import**, not just the tool-call detail inside it.

Reproduced before the fix:

```python
# 3 assistant/human turns in, only 2 survive — the tool-only turn is gone
```

(full repro is in the new test)

## The fix

- `tool_use` renders as the tool name plus its JSON input.
- `tool_result` renders as its text content.
- Both use the same rendering style already established for `thinking` blocks, rather than inventing a new convention.
- Any *other* unrecognized content type (images, documents, whatever Anthropic adds next) now becomes a visible `[unsupported content: type=X]` placeholder instead of vanishing — so a reader diffing the import against the original knows to go look, rather than assuming the conversation was shorter than it actually was.

## Also fixed in the same area

`_parse_iso_datetime`'s numeric branch used `datetime.fromtimestamp()` with no `tz`, i.e. local system time, while the ISO-string branch (what Claude's real exports actually use) is always UTC. Comparing one aware and one naive datetime raises `TypeError` outright, so a thinking block mixing the two timestamp shapes would crash conversion for the whole file. Pinned the numeric branch to UTC to match.

To be upfront: I haven't personally observed a real Claude export mixing timestamp shapes within one block (both fields normally come from the same field format), so this one is defensive rather than a confirmed real-world crash — unlike the `tool_use` finding above, which I hit and verified directly.

## Tests

- `examples/claude_tooluse_example.json` + `tests/expected/claude_tooluse_output.json`: a `tool_use`+`tool_result`+`text` turn, a `tool_use`+`tool_result`-*only* turn (the one that used to vanish), and one unrecognized content type.
- `test_claude_tooluse_conversion` asserts all 5 input messages survive.
- `test_reasoning_block_mixed_timestamp_types` is a direct regression test for the timestamp fix.

## Scope note

`test_chatgpt_conversion`, `test_grok_conversion`, and `test_invalid_unicode` fail on `main` today, unrelated to this change — I confirmed this by running the suite before touching anything. Left untouched deliberately: I have direct, firsthand familiarity with Claude's real export format from having debugged an actual migration against it, and no comparable basis for auditing the ChatGPT/Grok converters. The two existing Claude tests (`test_claude_conversion`, `test_claude_thinking_conversion`) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)